### PR TITLE
19 replace const generics with attributes

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -4,7 +4,7 @@ use quant::register::Register;
 
 
 fn main() {
-    let mut register = Register::new([false, true, true]);
+    let mut register = Register::new(vec![false, true, true]);
 
     register.state = Complex::new(1.0 / f64::sqrt(4.0), 0.0) * array![
         [Complex::new(0.0, 0.0)],
@@ -20,7 +20,7 @@ fn main() {
     register.print_probabilities();
 
     println!("{}", register.measure(1));
-    let mut register = Register::new([true, false, false]);
+    let mut register = Register::new(vec![true, false, false]);
 
     register.print_probabilities();
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -4,7 +4,7 @@ use quant::register::Register;
 
 
 fn main() {
-    let mut register = Register::new(vec![false, true, true]);
+    let mut register = Register::new(&[false, true, true]);
 
     register.state = Complex::new(1.0 / f64::sqrt(4.0), 0.0) * array![
         [Complex::new(0.0, 0.0)],
@@ -20,7 +20,7 @@ fn main() {
     register.print_probabilities();
 
     println!("{}", register.measure(1));
-    let mut register = Register::new(vec![true, false, false]);
+    let mut register = Register::new(&[true, false, false]);
 
     register.print_probabilities();
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -10,13 +10,14 @@ pub trait OperationTrait {
 }
 
 #[derive(Clone, Debug)]
-pub struct Operation<const ARITY: usize> {
+pub struct Operation {
     matrix: Array2<Complex<f64>>,
-    targets: [usize; ARITY],
+    targets: Vec<usize>,
+    arity: usize
 }
 
 // TODO: Check if we can return references instead?
-impl<const ARITY: usize> OperationTrait for Operation<ARITY> {
+impl OperationTrait for Operation {
     fn matrix(&self) -> Array2<Complex<f64>> {
         self.matrix.clone()
     }
@@ -26,25 +27,27 @@ impl<const ARITY: usize> OperationTrait for Operation<ARITY> {
     }
 
     fn arity(&self) -> usize {
-        ARITY
+        self.arity
     }
 }
 
-pub fn identity(target: usize) -> Operation<1> {
+pub fn identity(target: usize) -> Operation {
     Operation {
         matrix: real_to_complex(array![[1.0, 0.0], [0.0, 1.0]]),
-        targets: [target],
+        targets: vec![target],
+        arity: 1
     }
 }
 
-pub fn hadamard(target: usize) -> Operation<1> {
+pub fn hadamard(target: usize) -> Operation {
     Operation {
         matrix: real_to_complex(consts::FRAC_1_SQRT_2 * array![[1.0, 1.0], [1.0, -1.0]]),
-        targets: [target],
+        targets: vec![target],
+        arity: 1
     }
 }
 
-pub fn cnot(control: usize, target: usize) -> Operation<2> {
+pub fn cnot(control: usize, target: usize) -> Operation {
     Operation {
         matrix: real_to_complex(array![
             [1.0, 0.0, 0.0, 0.0],
@@ -52,11 +55,12 @@ pub fn cnot(control: usize, target: usize) -> Operation<2> {
             [0.0, 0.0, 0.0, 1.0],
             [0.0, 0.0, 1.0, 0.0]
         ]),
-        targets: [control, target],
+        targets: vec![control, target],
+        arity: 2
     }
 }
 
-pub fn swap(target1: usize, target2: usize) -> Operation<2> {
+pub fn swap(target1: usize, target2: usize) -> Operation {
     Operation {
         matrix: real_to_complex(array![
             [1.0, 0.0, 0.0, 0.0],
@@ -64,41 +68,46 @@ pub fn swap(target1: usize, target2: usize) -> Operation<2> {
             [0.0, 1.0, 0.0, 0.0],
             [0.0, 0.0, 0.0, 1.0]
         ]),
-        targets: [target1, target2],
+        targets: vec![target1, target2],
+        arity: 2
     }
 }
 
-pub fn phase(target: usize) -> Operation<1> {
+pub fn phase(target: usize) -> Operation {
     Operation {
         matrix: array![
             [Complex::new(1.0, 0.0), Complex::new(0.0, 0.0)],
             [Complex::new(0.0, 0.0), Complex::new(0.0, 1.0)]
         ],
-        targets: [target],
+        targets: vec![target],
+        arity: 1
     }
 }
 
-pub fn not(target: usize) -> Operation<1> {
+pub fn not(target: usize) -> Operation {
     Operation {
         matrix: real_to_complex(array![[0.0, 1.0], [1.0, 0.0]]),
-        targets: [target],
+        targets: vec![target],
+        arity: 1
     }
 }
 
-pub fn pauli_y(target: usize) -> Operation<1> {
+pub fn pauli_y(target: usize) -> Operation {
     Operation {
         matrix: array![
             [Complex::new(0.0, 0.0), Complex::new(0.0, -1.0)],
             [Complex::new(0.0, 1.0), Complex::new(0.0, 0.0)]
         ],
-        targets: [target],
+        targets: vec![target],
+        arity: 1
     }
 }
 
-pub fn pauli_z(target: usize) -> Operation<1> {
+pub fn pauli_z(target: usize) -> Operation {
     Operation {
         matrix: real_to_complex(array![[1.0, 0.0], [0.0, -1.0]]),
-        targets: [target],
+        targets: vec![target],
+        arity: 1
     }
 }
 

--- a/src/register.rs
+++ b/src/register.rs
@@ -45,7 +45,7 @@ impl Register {
     /// Applys a quantum operation to the current state
     ///
     /// Input a state and an operation. Outputs the new state
-    pub fn apply<const ARITY: usize>(&mut self, op: &Operation<ARITY>) -> &mut Self {
+    pub fn apply(&mut self, op: &Operation) -> &mut Self {
         // Gets the target bit
         let target = op.targets()[0];
         // Calculates the number of matrices in tensor product

--- a/src/register.rs
+++ b/src/register.rs
@@ -27,7 +27,7 @@ pub struct Register {
 impl Register {
 
     /// Creates a new state with an array of booleans with size N 
-    pub fn new(input_bits: Vec<bool>) -> Self {
+    pub fn new(input_bits: &[bool]) -> Self {
         // Complex 1 by 1 identity matrix
         let base_state = array![[Complex::new(1.0, 0.0)]]; 
         

--- a/src/register.rs
+++ b/src/register.rs
@@ -8,7 +8,7 @@ use rand::prelude::*;
 
 /// A quantum register containing N qubits.
 #[derive(Clone, Debug)]
-pub struct Register<const N: usize> {
+pub struct Register {
     /// Represents the state of the quantum register as a vector with 2^N complex elements.
     ///
     /// The state is a linear combination of the basis vectors:
@@ -20,13 +20,14 @@ pub struct Register<const N: usize> {
     /// The state vector is [a, b, c, ...]<sup>T</sup>, where |state_i|<sup>2</sup> represents the probability
     /// that the system will collapse into the state described by the ith basis vector.
     pub state: Array2<Complex<f64>>, // Should not be pub (it is pub now for testing purpouses)
+    size: usize
 }
 
 
-impl<const N: usize> Register<N> {
+impl Register {
 
     /// Creates a new state with an array of booleans with size N 
-    pub fn new(input_bits: [bool; N]) -> Self {
+    pub fn new(input_bits: Vec<bool>) -> Self {
         // Complex 1 by 1 identity matrix
         let base_state = array![[Complex::new(1.0, 0.0)]]; 
         
@@ -38,6 +39,7 @@ impl<const N: usize> Register<N> {
 
         Self {
             state: state_matrix,
+            size: input_bits.len()
         }
     }
     /// Applys a quantum operation to the current state
@@ -47,7 +49,7 @@ impl<const N: usize> Register<N> {
         // Gets the target bit
         let target = op.targets()[0];
         // Calculates the number of matrices in tensor product
-        let num_matrices = N + 1 - op.targets().len();
+        let num_matrices = self.size + 1 - op.targets().len();
 
         // If index i is equal to target bit returns matrix representation of operation
         // otherwise returns 2 by 2 identity matrix
@@ -76,7 +78,7 @@ impl<const N: usize> Register<N> {
     ///
     /// **Panics** if the supplied target is not less than the number of qubits in the register.
     pub fn measure(&mut self, target: usize) -> bool {
-        assert!(target < N);
+        assert!(target < self.size);
 
         let mut prob_1 = 0.0; // The probability of collapsing into a state where the target bit = 1
         let mut prob_0 = 0.0; // The probability of collapsing into a state where the target bit = 0
@@ -121,12 +123,13 @@ impl<const N: usize> Register<N> {
 
     /// Prints the probability in percent of falling into different states
     pub fn print_probabilities(&self) {
+        let n = self.size;
         for (i, s) in self.state.iter().enumerate() {
-            println!("{:0N$b}: {}%", i, s.norm_sqr() * 100.0);
+            println!("{:0n$b}: {}%", i, s.norm_sqr() * 100.0);
         }
     }
 }
-impl<const N: usize> PartialEq for Register<N> {
+impl PartialEq for Register {
     fn eq(&self, other: &Self) -> bool {
         (&self.state - &other.state).iter().all(|e| e.norm() < 1e-8)
     }

--- a/src/register.rs
+++ b/src/register.rs
@@ -47,7 +47,7 @@ impl Register {
     /// Input a state and an operation. Outputs the new state
     pub fn apply(&mut self, op: &Operation) -> &mut Self {
         // Gets the target bit
-        let target = op.targets()[ARITY - 1];
+        let target = op.targets()[op.arity() - 1];
         // Calculates the number of matrices in tensor product
         let num_matrices = self.size + 1 - op.targets().len();
 

--- a/tests/register_operation_tests.rs
+++ b/tests/register_operation_tests.rs
@@ -137,7 +137,7 @@ proptest!(
 );
 
 #[derive(Debug, Clone)]
-struct UnaryOperation(Operation<1>);
+struct UnaryOperation(Operation);
 
 impl Arbitrary for UnaryOperation {
     type Parameters = Range<usize>;
@@ -152,7 +152,7 @@ impl Arbitrary for UnaryOperation {
     }
 }
 #[derive(Debug, Clone)]
-struct BinaryOperation(Operation<2>);
+struct BinaryOperation(Operation);
 impl Arbitrary for BinaryOperation {
     type Parameters = Range<usize>;
     type Strategy = Select<BinaryOperation>;
@@ -169,7 +169,7 @@ impl Arbitrary for BinaryOperation {
     }
 }
 #[derive(Debug, Clone)]
-struct BinaryOperationAfterSwapIsImplemented(Operation<2>);
+struct BinaryOperationAfterSwapIsImplemented(Operation);
 impl Arbitrary for BinaryOperationAfterSwapIsImplemented {
     type Parameters = Range<usize>;
     type Strategy = Select<BinaryOperationAfterSwapIsImplemented>;

--- a/tests/register_operation_tests.rs
+++ b/tests/register_operation_tests.rs
@@ -10,7 +10,7 @@ use quant::register::Register;
 #[test]
 // #[ignore = "Wait for feature confirmation"]
 fn measure_on_zero_state_gives_false() {
-    let mut register = Register::new(vec![false]);
+    let mut register = Register::new(&[false]);
     let input = register.measure(0);
     let expected = false;
 
@@ -20,7 +20,7 @@ fn measure_on_zero_state_gives_false() {
 proptest!(
     #[test]
     fn test_not_on_arbitrary_qubit(i in 0..3) {
-        let mut register = Register::new(vec![false, false, false]);
+        let mut register = Register::new(&[false, false, false]);
         register.apply(&operation::not(i as usize));
         let input = register.measure(i as usize);
         let expected = true;
@@ -34,7 +34,7 @@ proptest!(
         state3 in any::<bool>(),
         state4 in any::<bool>()
     ) {
-        let mut register = Register::new(vec![state, state2, state3, state4]);
+        let mut register = Register::new(&[state, state2, state3, state4]);
         //                                  q0     q1       q2     q3
         let input = [
             register.measure(0),
@@ -58,7 +58,7 @@ proptest!(
         state7 in any::<bool>(),
         state8 in any::<bool>()
     ) {
-        let mut register = Register::new(vec![state, state2, state3, state4, state5, state6, state7, state8]);
+        let mut register = Register::new(&[state, state2, state3, state4, state5, state6, state7, state8]);
         let input = [
             register.measure(0),
             register.measure(1),
@@ -75,7 +75,7 @@ proptest!(
 
     #[test]
     fn hadamard_hadamard_retains_original_state(i in 0..3) {
-        let mut reg = Register::new(vec![false,false,false]);
+        let mut reg = Register::new(&[false,false,false]);
         let expected = reg.clone();
 
         let hadamard = operation::hadamard(i as usize);
@@ -87,7 +87,7 @@ proptest!(
     #[test]
     // #[ignore = "Indexing issue in register, is weird"]
     fn first_bell_state_measure_equal(i in 0..5 as usize) {
-        let mut reg = Register::new(vec![false; 6]);
+        let mut reg = Register::new(&[false; 6]);
         let hadamard = operation::hadamard(i+1);
         let cnot = operation::cnot(i, i+1);
 
@@ -102,7 +102,7 @@ proptest!(
 
     #[test]
     fn arbitrary_unary_applied_twice_gives_equal(op in UnaryOperation::arbitrary_with(0..6)) {
-        let mut reg = Register::new(vec![false; 6]);
+        let mut reg = Register::new(&[false; 6]);
         let expected = reg.clone();
 
         reg.apply(&op.0);
@@ -114,7 +114,7 @@ proptest!(
 
     #[test]
     fn arbitrary_binary_applied_twice_gives_equal(op in BinaryOperation::arbitrary_with(0..6)) {
-        let mut reg = Register::new(vec![false; 6]);
+        let mut reg = Register::new(&[false; 6]);
         let expected = reg.clone();
 
         reg.apply(&op.0);
@@ -125,7 +125,7 @@ proptest!(
     #[test]
     #[ignore = "Apply does not figure out how to swap bits"]
     fn arbitrary_binary_applied_twice_gives_equal_after_swap_is_implemented(op in BinaryOperationAfterSwapIsImplemented::arbitrary_with(0..6)) {
-        let mut reg = Register::new(vec![false; 6]);
+        let mut reg = Register::new(&[false; 6]);
         let expected = reg.clone();
 
         reg.apply(&op.0);

--- a/tests/register_operation_tests.rs
+++ b/tests/register_operation_tests.rs
@@ -10,7 +10,7 @@ use quant::register::Register;
 #[test]
 // #[ignore = "Wait for feature confirmation"]
 fn measure_on_zero_state_gives_false() {
-    let mut register = Register::new([false]);
+    let mut register = Register::new(vec![false]);
     let input = register.measure(0);
     let expected = false;
 
@@ -20,7 +20,7 @@ fn measure_on_zero_state_gives_false() {
 proptest!(
     #[test]
     fn test_not_on_arbitrary_qubit(i in 0..3) {
-        let mut register = Register::new([false, false, false]);
+        let mut register = Register::new(vec![false, false, false]);
         register.apply(&operation::not(i as usize));
         let input = register.measure(i as usize);
         let expected = true;
@@ -34,7 +34,7 @@ proptest!(
         state3 in any::<bool>(),
         state4 in any::<bool>()
     ) {
-        let mut register = Register::new([state, state2, state3, state4]);
+        let mut register = Register::new(vec![state, state2, state3, state4]);
         //                                  q0     q1       q2     q3
         let input = [
             register.measure(0),
@@ -58,7 +58,7 @@ proptest!(
         state7 in any::<bool>(),
         state8 in any::<bool>()
     ) {
-        let mut register = Register::new([state, state2, state3, state4, state5, state6, state7, state8]);
+        let mut register = Register::new(vec![state, state2, state3, state4, state5, state6, state7, state8]);
         let input = [
             register.measure(0),
             register.measure(1),
@@ -75,7 +75,7 @@ proptest!(
 
     #[test]
     fn hadamard_hadamard_retains_original_state(i in 0..3) {
-        let mut reg = Register::new([false,false,false]);
+        let mut reg = Register::new(vec![false,false,false]);
         let expected = reg.clone();
 
         let hadamard = operation::hadamard(i as usize);
@@ -87,7 +87,7 @@ proptest!(
     #[test]
     // #[ignore = "Indexing issue in register, is weird"]
     fn first_bell_state_measure_equal(i in 0..5 as usize) {
-        let mut reg = Register::new([false; 6]);
+        let mut reg = Register::new(vec![false; 6]);
         let hadamard = operation::hadamard(i+1);
         let cnot = operation::cnot(i, i+1);
 
@@ -102,7 +102,7 @@ proptest!(
 
     #[test]
     fn arbitrary_unary_applied_twice_gives_equal(op in UnaryOperation::arbitrary_with(0..6)) {
-        let mut reg = Register::new([false; 6]);
+        let mut reg = Register::new(vec![false; 6]);
         let expected = reg.clone();
 
         reg.apply(&op.0);
@@ -114,7 +114,7 @@ proptest!(
 
     #[test]
     fn arbitrary_binary_applied_twice_gives_equal(op in BinaryOperation::arbitrary_with(0..6)) {
-        let mut reg = Register::new([false; 6]);
+        let mut reg = Register::new(vec![false; 6]);
         let expected = reg.clone();
 
         reg.apply(&op.0);
@@ -125,7 +125,7 @@ proptest!(
     #[test]
     #[ignore = "Apply does not figure out how to swap bits"]
     fn arbitrary_binary_applied_twice_gives_equal_after_swap_is_implemented(op in BinaryOperationAfterSwapIsImplemented::arbitrary_with(0..6)) {
-        let mut reg = Register::new([false; 6]);
+        let mut reg = Register::new(vec![false; 6]);
         let expected = reg.clone();
 
         reg.apply(&op.0);


### PR DESCRIPTION
Refactores the code to use attributes instead of const generics.

Note that some of the structs used in the proptests now look redundant in their definitions. Should it be kept for structure or can we simplify it?
<img width="525" alt="image" src="https://user-images.githubusercontent.com/39124630/220659315-1f1ade33-bca0-48c0-ad67-9da0e97533f3.png">

Solves #19 