### PR TITLE
Fix cnot target and control bit order

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,30 +1,14 @@
-use ndarray::array;
-use num::Complex;
-use quant::register::Register;
+use quant::{register::Register, operation};
 
 
 fn main() {
-    let mut register = Register::new(&[false, true, true]);
-
-    register.state = Complex::new(1.0 / f64::sqrt(4.0), 0.0) * array![
-        [Complex::new(0.0, 0.0)],
-        [Complex::new(0.0, 0.0)],
-        [Complex::new(1.0, 0.0)],
-        [Complex::new(1.0, 0.0)],
-        [Complex::new(1.0, 0.0)],
-        [Complex::new(1.0, 0.0)],
-        [Complex::new(0.0, 0.0)],
-        [Complex::new(0.0, 0.0)],
-    ];
+    let mut register = Register::new(&[false, false]);
 
     register.print_probabilities();
 
-    println!("{}", register.measure(1));
-    let mut register = Register::new(&[true, false, false]);
+    register.apply(&operation::hadamard(0));
+    register.apply(&operation::cnot(0, 1));
 
-    register.print_probabilities();
-
-    println!("{}", register.measure(0));
-
+    println!();
     register.print_probabilities();
 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -55,7 +55,7 @@ pub fn cnot(control: usize, target: usize) -> Operation {
             [0.0, 0.0, 0.0, 1.0],
             [0.0, 0.0, 1.0, 0.0]
         ]),
-        targets: vec![control, target],
+        targets: vec![target, control],
         arity: 2,
     }
 }

--- a/tests/register_operation_tests.rs
+++ b/tests/register_operation_tests.rs
@@ -90,7 +90,7 @@ proptest!(
         let mut reg = Register::new(&[false; 6]);
 
         let hadamard = operation::hadamard(i);
-        let cnot = operation::cnot(i + 1, i);
+        let cnot = operation::cnot(i, i + 1);
 
         // maximally entangle qubit i and i + 1
         reg.apply(&hadamard);


### PR DESCRIPTION
Simply changes the order that the bits are stored in the target vector in the cnot gate.

Resolves: #14