### PR TITLE
Add possibility to apply unary operation to whole register easier

### DIFF
--- a/tests/register_operation_tests.rs
+++ b/tests/register_operation_tests.rs
@@ -169,6 +169,24 @@ proptest!(
         assert!(res);
     }
 
+    #[test]
+    fn apply_all_test(n in 2..=6 as usize) {
+        let mut reg1 = Register::new(&(0..n).map(|_| false).collect::<Vec<bool>>());
+        let mut reg2 = Register::new(&(0..n).map(|_| false).collect::<Vec<bool>>());
+        
+        (0..reg1.size()).for_each(|i| { reg1.apply(&operation::hadamard(i)); });
+        reg2.apply_all(&operation::hadamard(0));
+
+        assert!(reg1 == reg2)
+    }
+
+    #[test]
+    #[should_panic]
+    fn apply_all_panics_if_not_unary(op in BinaryOperation::arbitrary_with(0..6)) {
+        let mut reg = Register::new(&[false; 6]);
+        reg.apply_all(&op.0);
+    }
+
 );
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Resolves: #41 

I added the functions in the same fashion as the other "try" methods are written. I added one more error called "InvalidArityError" to highlight that not just the dimensions were wrong, the arity of the operation is. 

It is a bit awkward since the targets of the operations are essentially ignored. The user is allowed to call ```reg.apply_all(&hadamard(1000))``` if they want to. This is because we only care about the matrices, not the actual targets since the same should be applied everywhere. Do you have any suggestions as to how to handle this better? 