### PR TITLE
93 add support for running OpenQASM in CLI

### DIFF
--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -233,10 +233,10 @@ fn qubit_prompt<const N: usize>(
 /// Panics if an error occurs during any of the prompts or if `size` == 0.
 fn get_unary(size: usize) -> Result<Operation, InquireError> {
     let unary_op =
-        unary_prompt().expect("Problem encountered when selecting unary operation: {e:?}");
+        unary_prompt().expect("Problem encountered when selecting unary operation");
 
     let target = qubit_prompt(unary_operation_target_name(&unary_op), size)
-        .expect("Problem encountered when selecting index: {e:?}")[0];
+        .expect("Problem encountered when selecting index")[0];
 
     let op = match unary_op {
         UnaryOperation::Identity => operation::identity(target),
@@ -259,10 +259,10 @@ fn get_unary(size: usize) -> Result<Operation, InquireError> {
 /// TODO: also panics if targets are not in ascending order.
 fn get_binary(size: usize) -> Result<Operation, InquireError> {
     let binary_op =
-        binary_prompt().expect("Problem encountered when selecting binary operation: {e:?}");
+        binary_prompt().expect("Problem encountered when selecting binary operation");
 
     let targets = qubit_prompt(binary_operation_target_names(&binary_op), size)
-        .expect("Problem encountered when selecting index: {e:?}");
+        .expect("Problem encountered when selecting index");
 
     let a = targets[0];
     let b = targets[1];
@@ -282,7 +282,7 @@ fn get_binary(size: usize) -> Result<Operation, InquireError> {
 /// Panics if an error occurs while selecting an operation or when the operation is applied.
 fn handle_apply(reg: &mut Register) {
     let op_type = operation_prompt(reg.size())
-        .expect("Problem encountered during operation type selection: {e:?}");
+        .expect("Problem encountered during operation type selection");
 
     let result = match op_type {
         OperationType::Unary => get_unary(reg.size()),
@@ -302,7 +302,7 @@ fn handle_apply(reg: &mut Register) {
 /// Panics if an error occurs while selecting an index.
 fn handle_measure(reg: &mut Register) {
     let index = qubit_prompt(["target"], reg.size())
-        .expect("Problem encountered when selecting a qubit: {e:?}")[0];
+        .expect("Problem encountered when selecting a qubit")[0];
 
     let result = reg.measure(index);
     println!("Qubit at index {index} measured {result}");
@@ -333,7 +333,7 @@ fn main() {
         n
     } else {
         // 4 max gives a nice wrapping, argument allows for bigger
-        size_prompt(4).expect("Problem when selecting a register size: {e:?}")
+        size_prompt(4).expect("Problem when selecting a register size")
     };
 
     let init_state = &[false].repeat(size);
@@ -343,7 +343,7 @@ fn main() {
     print!("{esc}[2J{esc}[1;1H", esc = 27 as char);
 
     loop {
-        let init = init_prompt().expect("Problem selecting an option: {e:?}");
+        let init = init_prompt().expect("Problem selecting an option");
 
         print!("{esc}[2J{esc}[1;1H", esc = 27 as char);
 

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -232,15 +232,11 @@ fn qubit_prompt<const N: usize>(
 ///
 /// Panics if an error occurs during any of the prompts or if `size` == 0.
 fn get_unary(size: usize) -> Result<Operation, InquireError> {
-    let unary_op = match unary_prompt() {
-        Ok(op) => op,
-        Err(e) => panic!("Problem encountered when selecting unary operation: {e:?}"),
-    };
+    let unary_op =
+        unary_prompt().expect("Problem encountered when selecting unary operation: {e:?}");
 
-    let target = match qubit_prompt(unary_operation_target_name(&unary_op), size) {
-        Ok(ts) => ts[0],
-        Err(e) => panic!("Problem encountered when selecting index: {e:?}"),
-    };
+    let target = qubit_prompt(unary_operation_target_name(&unary_op), size)
+        .expect("Problem encountered when selecting index: {e:?}")[0];
 
     let op = match unary_op {
         UnaryOperation::Identity => operation::identity(target),
@@ -262,15 +258,11 @@ fn get_unary(size: usize) -> Result<Operation, InquireError> {
 /// Panics if an error occurs during any of the prompts or if `size` < 2.
 /// TODO: also panics if targets are not in ascending order.
 fn get_binary(size: usize) -> Result<Operation, InquireError> {
-    let binary_op = match binary_prompt() {
-        Ok(op) => op,
-        Err(e) => panic!("Problem encountered when selecting binary operation: {e:?}"),
-    };
+    let binary_op =
+        binary_prompt().expect("Problem encountered when selecting binary operation: {e:?}");
 
-    let targets = match qubit_prompt(binary_operation_target_names(&binary_op), size) {
-        Ok(ts) => ts,
-        Err(e) => panic!("Problem encountered when selecting index: {e:?}"),
-    };
+    let targets = qubit_prompt(binary_operation_target_names(&binary_op), size)
+        .expect("Problem encountered when selecting index: {e:?}");
 
     let a = targets[0];
     let b = targets[1];
@@ -289,10 +281,8 @@ fn get_binary(size: usize) -> Result<Operation, InquireError> {
 /// # Panics
 /// Panics if an error occurs while selecting an operation or when the operation is applied.
 fn handle_apply(reg: &mut Register) {
-    let op_type = match operation_prompt(reg.size()) {
-        Ok(op_type) => op_type,
-        Err(e) => panic!("Problem encountered during operation type selection: {e:?}"),
-    };
+    let op_type = operation_prompt(reg.size())
+        .expect("Problem encountered during operation type selection: {e:?}");
 
     let result = match op_type {
         OperationType::Unary => get_unary(reg.size()),
@@ -311,10 +301,9 @@ fn handle_apply(reg: &mut Register) {
 /// # Panics
 /// Panics if an error occurs while selecting an index.
 fn handle_measure(reg: &mut Register) {
-    let index = match qubit_prompt(["target"], reg.size()) {
-        Ok(ts) => ts[0],
-        Err(e) => panic!("Problem encountered when selecting a qubit: {e:?}"),
-    };
+    let index = qubit_prompt(["target"], reg.size())
+        .expect("Problem encountered when selecting a qubit: {e:?}")[0];
+
     let result = reg.measure(index);
     println!("Qubit at index {index} measured {result}");
 }
@@ -344,10 +333,7 @@ fn main() {
         n
     } else {
         // 4 max gives a nice wrapping, argument allows for bigger
-        match size_prompt(4) {
-            Ok(size) => size,
-            Err(e) => panic!("Problem when selecting a register size: {e:?}"),
-        }
+        size_prompt(4).expect("Problem when selecting a register size: {e:?}")
     };
 
     let init_state = &[false].repeat(size);
@@ -357,10 +343,7 @@ fn main() {
     print!("{esc}[2J{esc}[1;1H", esc = 27 as char);
 
     loop {
-        let init = match init_prompt() {
-            Ok(choice) => choice,
-            Err(e) => panic!("Problem selecting an option: {e:?}"),
-        };
+        let init = init_prompt().expect("Problem selecting an option: {e:?}");
 
         print!("{esc}[2J{esc}[1;1H", esc = 27 as char);
 

--- a/src/openqasm.rs
+++ b/src/openqasm.rs
@@ -1,9 +1,7 @@
 //! Code related to running openqasm programs on the simulator.
 
 use crate::{operation, register::Register};
-use openqasm_parser::openqasm::{
-    self, BasicOp, OpenQASMError as OpenQASMParseError,
-};
+use openqasm_parser::openqasm::{self, BasicOp, OpenQASMError as OpenQASMParseError};
 use std::{collections::HashMap, path::Path};
 
 /// A tuple containing some quantum registers and classical registers
@@ -16,6 +14,7 @@ pub struct Registers {
 }
 
 /// The different types of errors that can occur when running an openqasm program.
+#[derive(Debug)]
 pub enum OpenQASMError {
     /// Error when parsing the openqasm file. The problem can be with reading the file,
     /// parsing the tokens, syntax or semantics.
@@ -44,8 +43,8 @@ pub enum OpenQASMError {
 /// let registers = openqasm::run_openqasm(Path::new("filepath.qasm"));
 /// ```
 pub fn run_openqasm(openqasm_file: &Path) -> Result<Registers, OpenQASMError> {
-    let program = openqasm::parse_openqasm(openqasm_file)
-        .map_err(OpenQASMError::OpenQASMParseError)?;
+    let program =
+        openqasm::parse_openqasm(openqasm_file).map_err(OpenQASMError::OpenQASMParseError)?;
 
     // Initializes the registers defined in the openqasm file. All registers are initialized
     // to 0.


### PR DESCRIPTION
Resolves: #93

The overarching goal of this pull request is to support OpenQASM in CLI. To acomplish this it also makes some other changes in the CLI. Most notably, it modifies the CLI to support multiple quantum and classical registers. This change in turn also requires modifications when running commands that operate on registers (`Show`, `Measure`, `Apply`). These commands now prompt for a register. In order to not unnecessarily change the behavior of the CLI for the user, no prompt is shown if only one register of the desired type exists.

Because it doesn't make sense to `Show`, `Measure` or `Apply` when there are no registers the options are hidden until a quantum register is created.

The `Measure` command works like before, except it can optionally measure into a classical register instead of just printing the result. When no classical registers exists there is no change in behavior for the user.

The two new "main" options are `Create` and `OpenQASM` which reates a new register, or runs an OpenQASM program.

When creating a new register the user provides a name for the register, this name is validated to make sure that it is not already used.

When running an OpenQASM program the user provides a filepath, the filepath is validated to make sure that it is a correct filepath, and that the program is valid.