### PR TITLE
Add env_logger initialization

### DIFF
--- a/examples/shors.rs
+++ b/examples/shors.rs
@@ -23,6 +23,8 @@ struct Args {
 }
 
 fn main() {
+    env_logger::init();
+
     let args = Args::parse();
     let number = args.number;
     let n_times = args.n_times;


### PR DESCRIPTION
Resolves #102 

Use `RUST_LOG=debug cargo run --example shors` to see debug prints.
